### PR TITLE
Adding Image Rotation Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ args = {
 	origin_y: 0
 	scale_x: 1.0 ' The image scale.
 	scale_y: 1.0
+	rotation: 0 ' The image rotation in degrees
 	color: &hFFFFFF ' This can be used to tint the image with the provided color if desired. White makes no change to the original image.
 	alpha: 255 ' Change the image alpha (transparency).
 	enabled: true ' Whether or not the image will be drawn.
@@ -268,6 +269,8 @@ args = {
 	animation_position: 0 ' This would not normally be changed manually, but if you wanted to stop on a specific image in the spritesheet this could be set.
 }
 ```
+Note: Rotating and scaling an image at the same time has serious performance implications as Roku does not provide a method to draw an object with both scale and rotation. It is handled internally by creating an roBitmap to act as a canvas for the scaled drawing, the image is then drawn with rotation to the screen, then the roBitmap is removed.
+
 ##### getImage([image_name as String]) as Object
 Returns the image with the provided image name. Defaults to "main" image name.
 ##### removeImage([image_name as String])

--- a/gameEngine.brs
+++ b/gameEngine.brs
@@ -378,6 +378,12 @@ function new_game(canvas_width, canvas_height, debug = false, canvas_as_screen_i
 						else if image.rotation <> 0
 							draw_pos = Math_NewVector(image_pos_x, image_pos_y)
 							origin_pos = Math_NewVector(image_pos_x - origin_offset_x, image_pos_y - origin_offset_y)
+							if image.scale_x < 0
+								draw_pos.x += (image.region.GetWidth() * image.scale_x)
+							end if
+							if image.scale_y < 0
+								draw_pos.y += (image.region.GetHeight() * image.scale_y)
+							end if
 							rotated_pos = Math_RotateVectorAroundVector(draw_pos, origin_pos, Math_DegreesToRadians(image.rotation))
 							if image.scale_x = 1 and image.scale_y = 1
 								image.draw_to.DrawRotatedObject(rotated_pos.x, rotated_pos.y, image.rotation, image.region, (image.color << 8)+int(image.alpha))

--- a/gameEngine.brs
+++ b/gameEngine.brs
@@ -367,12 +367,23 @@ function new_game(canvas_width, canvas_height, debug = false, canvas_as_screen_i
 				for each image in instance.images
 					if image.enabled then
 						if image.alpha > 255 then : image.alpha = 255 : end if
-						image_pos_x = cint(instance.x+image.offset_x-(image.origin_x*image.scale_x))
-						image_pos_y = cint(instance.y+image.offset_y-(image.origin_y*image.scale_y))
-						if image.scale_x <> 1 or image.scale_y <> 1
-							image.draw_to.DrawScaledObject(image_pos_x, image_pos_y, image.scale_x, image.scale_y, image.region, (image.color << 8)+int(image.alpha))
-						else
+						origin_offset_x = -(image.origin_x*image.scale_x)
+						origin_offset_y = -(image.origin_y*image.scale_y)
+						image_pos_x = cint(instance.x + image.offset_x + origin_offset_x)
+						image_pos_y = cint(instance.y + image.offset_y + origin_offset_y)
+						if image.scale_x = 1 and image.scale_y = 1 and image.rotation = 0
 							image.draw_to.DrawObject(image_pos_x, image_pos_y, image.region, (image.color << 8)+int(image.alpha))
+						else if image.rotation = 0 and (image.scale_x <> 1 or image.scale_y <> 1)
+							image.draw_to.DrawScaledObject(image_pos_x, image_pos_y, image.scale_x, image.scale_y, image.region, (image.color << 8)+int(image.alpha))
+						else if image.rotation <> 0
+							draw_pos = Math_NewVector(image_pos_x, image_pos_y)
+							origin_pos = Math_NewVector(image_pos_x - origin_offset_x, image_pos_y - origin_offset_y)
+							rotated_pos = Math_RotateVectorAroundVector(draw_pos, origin_pos, Math_DegreesToRadians(image.rotation))
+							if image.scale_x = 1 and image.scale_y = 1
+								image.draw_to.DrawRotatedObject(rotated_pos.x, rotated_pos.y, image.rotation, image.region, (image.color << 8)+int(image.alpha))
+							else
+								DrawScaledAndRotatedObject(image.draw_to, rotated_pos.x, rotated_pos.y, image.scale_x, image.scale_y, image.rotation, image.region, (image.color << 8)+int(image.alpha))
+							end if
 						end if
 					end if
 				end for
@@ -622,6 +633,7 @@ function new_game(canvas_width, canvas_height, debug = false, canvas_as_screen_i
 				origin_y: 0
 				scale_x: 1.0 ' The image scale.
 				scale_y: 1.0
+				rotation: 0
 				color: &hFFFFFF ' This can be used to tint the image with the provided color if desired. White makes no change to the original image.
 				alpha: 255 ' Change the image alpha (transparency).
 				enabled: true ' Whether or not the image will be drawn.

--- a/gameMath.brs
+++ b/gameMath.brs
@@ -1,0 +1,111 @@
+function Math_Clamp(number, min, max)
+	if number < min
+		return min
+	else if number > max
+		return max
+	else
+		return number
+	end if
+end function
+
+function Math_PI()
+	return 3.1415926535897932384626433832795
+end function
+
+function Math_Atan2(y as float, x as float)
+    if x > 0
+		angle = Atn(y/x)
+	else if y >= 0 and x < 0
+		angle = Atn(y/x)+3.14159265359
+	else if y < 0 and x < 0
+		angle = Atn(y/x)-3.14159265359
+	else if y > 0 and x = 0
+		angle = 3.14159265359/2
+	else if y < 0 and x = 0
+		angle = (3.14159265359/2)*-1
+	else
+		angle = 0
+	end if
+
+	return angle
+end function
+
+function Math_IsIntegerEven(number as integer) as boolean
+	return (number MOD 2 = 0)
+end function
+
+function Math_IsIntegerOdd(number as integer) as boolean
+	return (number MOD 2 <> 0)
+end function
+
+function Math_DegreesToRadians(degrees as float) as float
+	return (degrees / 180) * Math_PI()
+end function
+
+function Math_RadiansToDegrees(radians as float) as float
+	return (180 / Math_PI()) * radians
+end function
+
+function Math_RandomRange(lowest_int as integer, highest_int as integer)
+	return rnd(highest_int - (lowest_int - 1)) + (lowest_int - 1)
+end function
+
+function Math_RotateVectorAroundVector(vector1 as object, vector2 as object, radians as float) as object
+	v = Math_NewVector(vector1.x, vector1.y)
+	s = sin(radians)
+	c = cos(radians)
+
+    v.x -= vector2.x
+    v.y -= vector2.y
+
+    new_x = v.x * c + v.y * s
+    new_y = -v.x * s + v.y * c
+
+    v.x = new_x + vector2.x
+    v.y = new_y + vector2.y
+    
+    return v
+end function
+
+function Math_NewVector(x = 0, y = 0) as object
+	return {x: x, y: y}
+end function
+
+function Math_NewRectangle(x as integer, y as integer, width as integer, height as integer) as object
+	rect = {
+		x: x
+		y: y
+		width: width
+		height: height
+	}
+
+	rect.Right = function() as integer
+		return m.x + m.width
+	end function
+
+	rect.Left = function() as integer
+		return m.x
+	end function
+
+	rect.Top = function() as integer
+		return m.y
+	end function
+
+	rect.Bottom = function() as integer
+		return m.y + m.height
+	end function
+
+	rect.Center = function() as object
+		return {x: m.x + m.width / 2, y: m.y + m.height / 2}
+	end function
+
+	rect.Copy = function() as object
+		return Math_NewRectangle(m.x, m.y, m.width, m.height)
+	end function
+
+	return rect
+end function
+
+function Math_NewCircle(x as integer, y as integer, radius as float) as object
+	return {x: x, y: y, radius: radius}
+end function

--- a/gameMath.brs
+++ b/gameMath.brs
@@ -46,7 +46,7 @@ function Math_RadiansToDegrees(radians as float) as float
 	return (180 / Math_PI()) * radians
 end function
 
-function Math_RandomRange(lowest_int as integer, highest_int as integer)
+function Math_RandomRange(lowest_int as integer, highest_int as integer) as integer
 	return rnd(highest_int - (lowest_int - 1)) + (lowest_int - 1)
 end function
 
@@ -108,4 +108,17 @@ end function
 
 function Math_NewCircle(x as integer, y as integer, radius as float) as object
 	return {x: x, y: y, radius: radius}
+end function
+
+function Math_TotalDistance(vector1 as object, vector2 as object) as object
+	x_distance = vector1.x - vector2.x
+	y_distance = vector1.y - vector2.y
+	total_distance = Sqr(x_distance * x_distance + y_distance * y_distance)
+	return total_distance
+end function
+
+function Math_GetAngle(vector1 as object, vector2 as object) as float
+	x_distance = vector1.x - vector2.x
+	y_distance = vector1.y - vector2.y
+	return Math_Atan2(y_distance, x_distance) + Math_PI()
 end function

--- a/gameUtils.brs
+++ b/gameUtils.brs
@@ -1,19 +1,5 @@
 function atan2(y, x)
-	if x > 0
-		collision_angle = Atn(y/x)
-	else if y >= 0 and x < 0
-		collision_angle = Atn(y/x)+3.14159265359
-	else if y < 0 and x < 0
-		collision_angle = Atn(y/x)-3.14159265359
-	else if y > 0 and x = 0
-		collision_angle = 3.14159265359/2
-	else if y < 0 and x = 0
-		collision_angle = (3.14159265359/2)*-1
-	else
-		collision_angle = 0
-	end if
-
-	return collision_angle
+	return Math_Atan2(y, x)
 end function
 
 function HSVtoRGB(h%,s%,v%,a = invalid) as integer
@@ -81,6 +67,17 @@ function DrawText(draw2d as object, text as string, x as integer, y as integer, 
 		draw2d.DrawText(text, x-font.GetOneLineWidth(text, 10000), y, color, font)
 	else if alignment = "center"
 		draw2d.DrawText(text, x-font.GetOneLineWidth(text, 10000)/2, y, color, font)
+	end if
+end function
+
+function DrawScaledAndRotatedObject(draw2d as object, x as float, y as float, scale_x as float, scale_y as float, theta as float, drawable as object, color = &hFFFFFFFF as integer) as void
+	new_width = Abs(int(drawable.GetWidth() * scale_x))
+	new_height = Abs(int(drawable.GetHeight() * scale_y))
+	if new_width <> 0 and new_height <> 0
+		new_drawable = CreateObject("roBitmap", {width: new_width, height: new_height, AlphaEnable: true})
+		new_drawable.DrawScaledObject(0, 0, scale_x, scale_y, drawable)
+		draw2d.ifDraw2D.DrawRotatedObject(x, y, theta, new_drawable, color)
+		new_drawable = invalid
 	end if
 end function
 

--- a/gameUtils.brs
+++ b/gameUtils.brs
@@ -75,7 +75,15 @@ function DrawScaledAndRotatedObject(draw2d as object, x as float, y as float, sc
 	new_height = Abs(int(drawable.GetHeight() * scale_y))
 	if new_width <> 0 and new_height <> 0
 		new_drawable = CreateObject("roBitmap", {width: new_width, height: new_height, AlphaEnable: true})
-		new_drawable.DrawScaledObject(0, 0, scale_x, scale_y, drawable)
+		scaled_draw_x = 0
+		scaled_draw_y = 0
+		if scale_x < 0
+			scaled_draw_x = new_width
+		end if
+		if scale_y < 0
+			scaled_draw_y = new_height
+		end if
+		new_drawable.DrawScaledObject(scaled_draw_x, scaled_draw_y, scale_x, scale_y, drawable)
 		draw2d.ifDraw2D.DrawRotatedObject(x, y, theta, new_drawable, color)
 		new_drawable = invalid
 	end if


### PR DESCRIPTION
Fixes #16 

This adds adds a rotation property to images. Note that there is no method to draw an object with both a scale and rotation on the Roku, so if an image has both scale and rotation set to something other than default it will substantially impact performance (as doing so requires the creation of a temporary bitmap and executing multiple draw calls).