### PR TITLE
Updating Image Object Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,15 +243,15 @@ Adds a circular collider to the instance's colliders associative array with the 
 Returns the collider with the provided name, returns invalid if it doesn't exist.
 ##### removeCollider(collider_name)
 Removes the collider with the provided name.
-##### addImage(image as Object, [args as Object, insert_position as Integer])
-Adds the provided image to the instance's images array. The image should be of type roBitmap or roRegion. By default images are added to the end of the images array but you can also choose to insert the image to a specific position in the array with the insert_position argument. Images drawn in the order they exist in the instance's images array. Args is an associative array with values to override the defaults. Here are the defaults that can be overridden.
+##### addImage(bitmap as Object, [args as Object, insert_position as Integer])
+Adds the provided image to the instance's images array. The image should be of type roBitmap. By default images are added to the end of the images array but you can also choose to insert the image to a specific position in the array with the insert_position argument. Images are drawn in the order they exist in the instance's images array. Args is an associative array with values to override the defaults. Here are the defaults that can be overridden.
 
 ```brightscript
 args = {
 	name: "main" ' Name must be unique
 	offset_x: 0 ' The offset of the image.
 	offset_y: 0 
-	origin_x: 0 ' The image origin (where it will be drawn from). This helps for keeping an image in the correct position even when scaling.
+	origin_x: 0 ' The image origin (where it will be drawn from). This helps for keeping an image in the correct position even when scaling and rotating.
 	origin_y: 0
 	scale_x: 1.0 ' The image scale.
 	scale_y: 1.0

--- a/gameEngine.brs
+++ b/gameEngine.brs
@@ -661,7 +661,6 @@ function new_game(canvas_width, canvas_height, debug = false, canvas_as_screen_i
 				animation_timer: invalid
 				previous_animation_position: 0
 			}
-			image_object.image = image_object.bitmap ' This is just for backwards compatability
 
 			for each key in image_object
 				if args.DoesExist(key) then

--- a/gameEngine.brs
+++ b/gameEngine.brs
@@ -344,15 +344,15 @@ function new_game(canvas_width, canvas_height, debug = false, canvas_as_screen_i
 							end if
 						end if
 					end if
-					if image_object.animation_position <> image_object.previous_animation_position
-						image_width = image_object.image.GetWidth()
+					if image_object.animation_position <> image_object.previous_animation_position and image_object.image_width <> invalid and image_object.image_height <> invalid
+						bitmap_width = image_object.bitmap.GetWidth()
 						region_position = int(image_object.animation_position)
-						region_width = image_object.region.GetWidth()
-						region_height = image_object.region.GetHeight()
+						region_width = image_object.image_width
+						region_height = image_object.image_height
 
-						y_offset = region_position*region_width \ image_width
-						x_offset = region_position*region_width-image_width*y_offset
-						image_object.region = CreateObject("roRegion", image_object.image, x_offset, y_offset*region_height, region_width, region_height)
+						y_offset = region_position*region_width \ bitmap_width
+						x_offset = region_position*region_width-bitmap_width*y_offset
+						image_object.region = CreateObject("roRegion", image_object.bitmap, x_offset, y_offset*region_height, region_width, region_height)
 						image_object.previous_animation_position = image_object.animation_position
 					end if
 				end for
@@ -629,7 +629,7 @@ function new_game(canvas_width, canvas_height, debug = false, canvas_as_screen_i
 			end if
 		end function
 
-		new_object.addImage = function(image, args = {}, insert_position = invalid)
+		new_object.addImage = function(bitmap, args = {}, insert_position = invalid)
 			image_object = {
 				' --------------Values That Can Be Changed------------
 				name: "main" ' Name must be unique
@@ -656,11 +656,13 @@ function new_game(canvas_width, canvas_height, debug = false, canvas_as_screen_i
 
 				' -------------Never To Be Manually Changed-----------------
 				' These values should never need to be manually changed.
-				image: image,
+				bitmap: bitmap
 				region: invalid
 				animation_timer: invalid
 				previous_animation_position: 0
 			}
+			image_object.image = image_object.bitmap ' This is just for backwards compatability
+
 			for each key in image_object
 				if args.DoesExist(key) then
 					image_object[key] = args[key]
@@ -677,11 +679,9 @@ function new_game(canvas_width, canvas_height, debug = false, canvas_as_screen_i
 			image_object.animation_timer = CreateObject_GameTimeSpan()
 
 			if image_object.image_width <> invalid and image_object.image_height <> invalid then
-				image_object.region = CreateObject("roRegion", image_object.image, 0, 0, args.image_width, args.image_height)
-			else if type(image) = "roRegion" then
-				image_object.region = image
+				image_object.region = CreateObject("roRegion", image_object.bitmap, 0, 0, args.image_width, args.image_height)
 			else
-				image_object.region = CreateObject("roRegion", image_object.image, 0, 0, image_object.image.GetWidth(), image_object.image.GetHeight())
+				image_object.region = CreateObject("roRegion", image_object.bitmap, 0, 0, image_object.bitmap.GetWidth(), image_object.bitmap.GetHeight())
 			end if
 
 			if insert_position = invalid


### PR DESCRIPTION
This removes the ability to provide an roRegion in the addImage() method. This is because internally roRegions are created for the sake of spritesheet animation, roRegions cannot be created from an roRegion, it must use roBitmap.

**NOTE: Potentially breaking change**
This update also changes the "image" property to "bitmap" for the sake of clarity. This can be potentially breaking to games that reference the "image" property.