### PR TITLE
Separating Draw Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ This will pause your game. Note: all instances that have _pauseable = false_ wil
 This will resume your paused game. Returns how long the game was paused in milliseconds if the game was paused, otherwise returns invalid if the game wasn't paused.
 ##### isPaused()
 Returns true if the game is paused.
-##### setBackgroundColor(color as Dynamic) as Void
-Set the color the canvas will be cleared with, if set to invalid the canvas will not be cleared.
 ##### getDeltaTime() as Float
 Returns the delta time. Note: Delta time is automatically applied to the built in instance xspeed and yspeed. Delta time is also automatically passed to the onUpdate(dt) function in every instance for convenience.
 ##### getRoom() as Object

--- a/gameEngine.brs
+++ b/gameEngine.brs
@@ -38,7 +38,6 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 		audioplayer: CreateObject("roAudioPlayer")
 		music_port: CreateObject("roMessagePort")
 		font_registry: CreateObject("roFontRegistry")
-		background_color: &h000000FF
 		screen: invalid
 		canvas: {
 			bitmap: CreateObject("roBitmap", {width: canvas_width, height: canvas_height, AlphaEnable: true})
@@ -67,7 +66,6 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 		newEmptyObject: invalid
 		drawColliders: invalid
 
-		setBackgroundColor: invalid
 		getDeltaTime: invalid
 		getRoom: invalid
 		getCanvas: invalid
@@ -176,19 +174,6 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 			end if
 			m.current_input_instance = m.input_instance
 			m.compositor.Draw() ' For some reason this has to be called or the colliders don't remove themselves from the compositor ¯\(°_°)/¯
-			if not m.canvas_is_screen
-				m.screen.Clear(&h000000FF)
-				if m.background_color <> invalid then
-					m.canvas.bitmap.Clear(m.background_color)
-				end if
-			else
-				if m.background_color <> invalid then
-					m.screen.Clear(m.background_color)
-				else
-					m.screen.Clear(&h000000FF)
-				end if
-			end if
-
 
 			m.dt = m.dtTimer.TotalMilliseconds()/1000
 			if m.FakeDT <> invalid
@@ -902,14 +887,6 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 		return m.paused
 	end function
 	' ############### isPaused() function - End ###############
-
-
-
-	' ############### setBackgroundColor() function - Begin ###############
-	game.setBackgroundColor = function(color as dynamic) as void
-		m.background_color = color
-	end function
-	' ############### setBackgroundColor() function - Begin ###############
 
 
 

--- a/gameEngine.brs
+++ b/gameEngine.brs
@@ -226,9 +226,6 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 
 			music_msg = m.music_port.GetMessage()
 
-			' -------------------Sort the instances according to depth before processing---------------------
-			m.sorted_instances.SortBy("depth")
-
 
 			' --------------------Begin giant loop for processing all game objects----------------
 			' There is a goto after every call to an override function, this is so if the instance deleted itself no futher calls will be attempted on the instance.
@@ -399,6 +396,7 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 			end for
 
 			' ----------------------Then draw all of the instances and call onDrawBegin() and onDrawEnd()-------------------------
+			m.sorted_instances.SortBy("depth")
 			for i = m.sorted_instances.Count()-1 to 0 step -1
 				instance = m.sorted_instances[i]
 				if instance = invalid or instance.id = invalid : goto end_of_draw_loop : end if
@@ -441,7 +439,6 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 				end if
 				end_of_draw_loop:
 			end for
-
 			' ------------------Destroy the UrlTransfer object if it has returned an event------------------
 			if type(url_msg) = "roUrlEvent"
 				url_transfer_id_string = url_msg.GetSourceIdentity().ToStr()
@@ -492,7 +489,6 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 			name: object_name
 			id: m.currentID.ToStr()
 			game: m
-			e_previous_sort_depth: invalid
 
 			' -----Variables-----
 			enabled: true

--- a/gameEngine.brs
+++ b/gameEngine.brs
@@ -420,10 +420,10 @@ function new_game(canvas_width, canvas_height, canvas_as_screen_if_possible = fa
 				end for
 				if instance.onDrawEnd <> invalid
 					instance.onDrawEnd(m.canvas.bitmap)
-					if instance = invalid or instance.id = invalid : goto end_of_draw_loop  : end if
 				end if
 				end_of_draw_loop:
 			end for
+
 			' ------------------Destroy the UrlTransfer object if it has returned an event------------------
 			if type(url_msg) = "roUrlEvent"
 				url_transfer_id_string = url_msg.GetSourceIdentity().ToStr()


### PR DESCRIPTION
This makes it so all drawing is done in a separate loop which occurs after the update loop. This means that all entities are processed before any drawing occurs as opposed to entities being drawn as they are processed.

This change alone marked a minor improvement to performance, but the curious thing is I then went on to investigate where the most time was being lost and it was on lines 179-191 where the screen was getting cleared. There is no reason that the screen needs to be cleared, so I completely removed that feature, which means any backgrounds will need to be drawn manually instead of being able to use setBackgroundColor().

The weird part about it is if I just removed that feature alone on the master branch it didn't give any performance improvements. There's something I'm not understanding about how these changes are optimizing drawing, but it's not really important. What's important is these changes provide major performance improvements.

Fixes #22 